### PR TITLE
Register code page encodings for file imports

### DIFF
--- a/UltraDES/DeterministicFiniteAutomaton.IO.cs
+++ b/UltraDES/DeterministicFiniteAutomaton.IO.cs
@@ -20,6 +20,11 @@ using DFA = DeterministicFiniteAutomaton;
 /// </summary>
 partial class DeterministicFiniteAutomaton
 {
+    static DeterministicFiniteAutomaton()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+
     /// <summary>
     /// Gets an XML string representation of the automaton.
     /// </summary>

--- a/UltraDES/UltraDES.csproj
+++ b/UltraDES/UltraDES.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.6.0" />
   </ItemGroup>
 


### PR DESCRIPTION
### Motivation
- File import APIs can fail on files encoded with legacy code pages (e.g. Windows-1252) because those encodings are not available by default on newer .NET runtimes; the change ensures the library works out-of-the-box across Windows, macOS and Linux without requiring callers to register encodings.

### Description
- Add a static constructor to `DeterministicFiniteAutomaton` that calls `Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);` so legacy code page encodings are available when the library is used.
- Add the `System.Text.Encoding.CodePages` package reference to `UltraDES/UltraDES.csproj` to provide the provider dependency at build/runtime.
- Changes made in `UltraDES/DeterministicFiniteAutomaton.IO.cs` and `UltraDES/UltraDES.csproj`.

### Testing
- Ran `dotnet build UltraDES/UltraDES.csproj` and the project built successfully.
- Executed a small test program that wrote an XML file in `windows-1252` and loaded it via `DeterministicFiniteAutomaton.FromXMLFile`, which succeeded and printed the automaton name.
- Ran `dotnet build UltraDES.sln` and the full solution built successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5136537dcc832cb784a99ca5f58808)