### PR TITLE
Fix automata composition with transitionless states

### DIFF
--- a/UltraDES/Data Structures/AdjacencyMatrix.cs
+++ b/UltraDES/Data Structures/AdjacencyMatrix.cs
@@ -76,8 +76,8 @@ namespace UltraDES
         }
 
         /// <summary>
-        /// Indexador: retorna a SortedList de transições (evento -> destino) para o estado 's'.
-        /// Se não existir, cria e retorna.
+        /// Indexador: retorna as transições (evento -> destino) para o estado 's'.
+        /// Retorna uma lista vazia quando o estado não possui transições.
         /// </summary>
         public List<(int e, int s)> this[int s] => _impl[s];
 

--- a/UltraDES/Data Structures/AdjacencyMatrix.cs
+++ b/UltraDES/Data Structures/AdjacencyMatrix.cs
@@ -11,13 +11,13 @@ namespace UltraDES
     [Serializable]
     internal sealed class AdjacencyMatrix
     {
-        // Mantém uma referência para a implementação escolhida
+        // Keeps a reference to the selected implementation
         private readonly IAdjacencyMatrixImplementation _impl;
 
         /// <summary>
-        /// Construtor principal. Se 'eventsNum' <= 64, usa implementação com bitmask (ulong),
-        /// caso contrário, usa BitArray.
-        /// O parâmetro 'preAllocate' pode ser repassado a ambas as implementações.
+        /// Main constructor. If 'eventsNum' <= 64, uses the bitmask (ulong) implementation,
+        /// otherwise, uses BitArray.
+        /// The 'preAllocate' parameter can be forwarded to both implementations.
         /// </summary>
         public AdjacencyMatrix(int states, int eventsNum, bool preAllocate = false)
         {
@@ -56,16 +56,16 @@ namespace UltraDES
             };
         }
 
-        // Construtor usado internamente para clone:
+        // Constructor used internally for cloning:
         private AdjacencyMatrix(IAdjacencyMatrixImplementation impl) => _impl = impl;
 
         /// <summary>
-        /// Retorna a quantidade de estados.
+        /// Returns the number of states.
         /// </summary>
         public int Length => _impl.Length;
 
         /// <summary>
-        /// Indexador: retorna o destino, ou -1 se não houver transição.
+        /// Indexer: returns the destination, or -1 when there is no transition.
         /// </summary>
         public int this[int s, int e] => _impl[s, e];
 
@@ -76,33 +76,33 @@ namespace UltraDES
         }
 
         /// <summary>
-        /// Indexador: retorna as transições (evento -> destino) para o estado 's'.
-        /// Retorna uma lista vazia quando o estado não possui transições.
+        /// Indexer: returns the transitions (event -> destination) for state 's'.
+        /// Returns an empty list when the state has no transitions.
         /// </summary>
         public List<(int e, int s)> this[int s] => _impl[s];
 
         /// <summary>
-        /// Verifica se o estado 's' tem o evento 'e'.
+        /// Checks whether state 's' has event 'e'.
         /// </summary>
         public bool HasEvent(int s, int e) => _impl.HasEvent(s, e);
 
         /// <summary>
-        /// Adiciona vários pares (evento, destino) em um único estado.
+        /// Adds multiple (event, destination) pairs to a single state.
         /// </summary>
         public void Add(int origin, (int, int)[] values) => _impl.Add(origin, values);
 
         /// <summary>
-        /// Adiciona um par (evento, destino) em um estado.
+        /// Adds an (event, destination) pair to a state.
         /// </summary>
         public void Add(int origin, int e, int dest) => _impl.Add(origin, e, dest);
 
         /// <summary>
-        /// Remove o evento 'e' do estado 'origin'.
+        /// Removes event 'e' from state 'origin'.
         /// </summary>
         public void Remove(int origin, int e) => _impl.Remove(origin, e);
 
         /// <summary>
-        /// Clona toda a matriz de adjacência (cópia profunda).
+        /// Clones the whole adjacency matrix (deep copy).
         /// </summary>
         public AdjacencyMatrix Clone()
         {
@@ -111,8 +111,8 @@ namespace UltraDES
         }
 
         /// <summary>
-        /// Tenta reduzir a quantidade de memória ocupada pelas coleções internas.
-        /// Em coleções grandes, pode ser útil.
+        /// Attempts to reduce the memory used by the internal collections.
+        /// This can be useful for large collections.
         /// </summary>
         public void TrimExcess() => _impl.TrimExcess();
     }

--- a/UltraDES/Data Structures/AdjacencyMatrixBDDImpl.cs
+++ b/UltraDES/Data Structures/AdjacencyMatrixBDDImpl.cs
@@ -37,9 +37,9 @@ namespace UltraDES
                 if (s < 0 || s >= Length || e < 0 || e >= EventsNum)
                     throw new IndexOutOfRangeException();
 
-                // Se ainda não existe, cria
+                // Creates it if it does not exist yet
                 _stateFunctions[s] ??= MTBDD.FullTree(0, numVars, -1);
-                // Avalia
+                // Evaluates
                 return _stateFunctions[s].Evaluate(e, numVars);
             }
         }
@@ -159,7 +159,7 @@ namespace UltraDES
             var clone = new AdjacencyMatrixBDDImpl(Length, EventsNum);
             for (int i = 0; i < Length; i++)
             {
-                // MTBDD é imutável, podemos compartilhar a mesma referência
+                // MTBDD is immutable, so we can share the same reference
                 clone._stateFunctions[i] = _stateFunctions[i];
             }
             return clone;
@@ -167,8 +167,8 @@ namespace UltraDES
 
         public void TrimExcess()
         {
-            // Se quisermos, poderíamos tentar reordenar variáveis ou 
-            // forçar minimizações adicionais. Mas no momento, nada é feito.
+            // If desired, we could try to reorder variables or
+            // force additional minimizations. For now, nothing is done.
         }
     }
 }

--- a/UltraDES/Data Structures/AdjacencyMatrixBitArray.cs
+++ b/UltraDES/Data Structures/AdjacencyMatrixBitArray.cs
@@ -10,7 +10,7 @@ namespace UltraDES
     internal sealed class AdjacencyMatrixBitArrayImpl : IAdjacencyMatrixImplementation
     {
         private readonly SortedList<int, int>[] _internal;
-        private readonly BitArray[] _events; // Cada estado tem um BitArray para marcar eventos
+        private readonly BitArray[] _events; // Each state has a BitArray to mark events
 
         public int Length => _internal.Length;
         public int EventsNum { get; }

--- a/UltraDES/Data Structures/AdjacencyMatrixBitArray.cs
+++ b/UltraDES/Data Structures/AdjacencyMatrixBitArray.cs
@@ -32,7 +32,9 @@ namespace UltraDES
         public int this[int s, int e]
             => HasEvent(s, e) ? _internal[s][e] : -1;
 
-        public List<(int, int)> this[int s] => _internal[s].Select(kvp => (kvp.Key, kvp.Value)).ToList();
+        public List<(int, int)> this[int s] => _internal[s] == null
+            ? new List<(int, int)>()
+            : _internal[s].Select(kvp => (kvp.Key, kvp.Value)).ToList();
 
 
         public bool HasEvent(int s, int e)

--- a/UltraDES/Data Structures/AdjacencyMatrixBitMask.cs
+++ b/UltraDES/Data Structures/AdjacencyMatrixBitMask.cs
@@ -38,7 +38,9 @@ namespace UltraDES
         public int this[int s, int e]
             => HasEvent(s, e) ? _internal[s][e] : -1;
 
-        public List<(int, int)> this[int s] => _internal[s].Select(kvp => (kvp.Key, kvp.Value)).ToList();
+        public List<(int, int)> this[int s] => _internal[s] == null
+            ? new List<(int, int)>()
+            : _internal[s].Select(kvp => (kvp.Key, kvp.Value)).ToList();
 
         public bool HasEvent(int s, int e)
         {

--- a/UltraDES/Data Structures/AdjacencyMatrixBitMask.cs
+++ b/UltraDES/Data Structures/AdjacencyMatrixBitMask.cs
@@ -7,10 +7,10 @@ namespace UltraDES
     [Serializable]
     internal sealed class AdjacencyMatrixBitMask : IAdjacencyMatrixImplementation
     {
-        // Cada estado tem uma SortedList<evento, destino>
+        // Each state has a SortedList<event, destination>
         private readonly SortedList<int, int>[] _internal;
 
-        // Cada estado tem um 'ulong' com bits marcados para indicar quais eventos existem
+        // Each state has a 'ulong' with marked bits indicating which events exist
         private readonly ulong[] _eventMask;
 
         public int Length => _internal.Length;
@@ -19,7 +19,7 @@ namespace UltraDES
         public AdjacencyMatrixBitMask(int states, int eventsNum, bool preAllocate = false)
         {
             if (eventsNum > 64)
-                throw new ArgumentException("Esta implementação só suporta até 64 eventos.", nameof(eventsNum));
+                throw new ArgumentException("This implementation only supports up to 64 events.", nameof(eventsNum));
 
             EventsNum = eventsNum;
             _internal = new SortedList<int, int>[states];
@@ -44,14 +44,14 @@ namespace UltraDES
 
         public bool HasEvent(int s, int e)
         {
-            // Verifica se o bit 'e' está marcado no estado 's'
+            // Checks whether bit 'e' is marked for state 's'
             ulong mask = 1UL << e;
             return (_eventMask[s] & mask) != 0;
         }
 
         public void Add(int origin, (int, int)[] values)
         {
-            // Se ainda não alocado, cria
+            // Creates the row if it has not been allocated yet
             if (_internal[origin] == null)
             {
                 _internal[origin] = new SortedList<int, int>(values.Length);
@@ -71,7 +71,7 @@ namespace UltraDES
                 }
                 else
                 {
-                    // Se já existe, checa determinismo
+                    // If it already exists, checks determinism
                     if (_internal[origin][e] != dest)
                         throw new Exception("Automaton is not deterministic.");
                 }
@@ -80,7 +80,7 @@ namespace UltraDES
 
         public void Add(int origin, int e, int dest)
         {
-            // Se ainda não alocado, cria
+            // Creates the row if it has not been allocated yet
             if (_internal[origin] == null)
             {
                 _internal[origin] = new SortedList<int, int>();
@@ -116,11 +116,11 @@ namespace UltraDES
             var clone = new AdjacencyMatrixBitMask(Length, EventsNum);
             for (int i = 0; i < Length; i++)
             {
-                // Clona a bitmask
+                // Clones the bitmask
                 clone._eventMask[i] = _eventMask[i];
                 if (_internal[i] != null)
                 {
-                    // Cria nova SortedList e copia
+                    // Creates a new SortedList and copies values
                     clone._internal[i] = new SortedList<int, int>();
                     foreach (var kv in _internal[i])
                     {
@@ -134,8 +134,8 @@ namespace UltraDES
 
         public void TrimExcess()
         {
-            // Para cada SortedList, chama TrimExcess
-            // (se for muito grande, avaliar se paralelizar faz sentido)
+            // Calls TrimExcess for each SortedList
+            // (if it is too large, evaluate whether parallelization makes sense)
             foreach (var sl in _internal)
             {
                 sl?.TrimExcess();

--- a/UltraDES/Data Structures/AdjacencyMatrixBoolArray.cs
+++ b/UltraDES/Data Structures/AdjacencyMatrixBoolArray.cs
@@ -5,14 +5,14 @@ using System.Linq;
 namespace UltraDES
 {
     /// <summary>
-    /// Implementação que usa bool[] por estado para marcar quais eventos existem.
-    /// Só será utilizada se a quantidade de estados for menor que 1000 (critério dado).
+    /// Implementation that uses bool[] per state to mark which events exist.
+    /// It is only used if the number of states is less than 1000 (given criterion).
     /// </summary>
     [Serializable]
     internal sealed class AdjacencyMatrixBoolArrayImpl : IAdjacencyMatrixImplementation
     {
         private readonly SortedList<int, int>[] _internal;
-        private readonly bool[][] _events;  // Para cada estado, um array de bool com tamanho EventsNum
+        private readonly bool[][] _events;  // For each state, a bool array with size EventsNum
 
         public int Length => _internal.Length;
         public int EventsNum { get; }
@@ -34,30 +34,30 @@ namespace UltraDES
         }
 
         /// <summary>
-        /// Indexador [s, e]: retorna destino ou -1 se não existir transição
+        /// Indexer [s, e]: returns the destination or -1 if the transition does not exist
         /// </summary>
         public int this[int s, int e]
             => HasEvent(s, e) ? _internal[s][e] : -1;
 
         /// <summary>
-        /// Indexador [s]: retorna as transições do estado ou uma lista vazia quando não houver nenhuma.
+        /// Indexer [s]: returns the state transitions or an empty list when there are none.
         /// </summary>
         public List<(int, int)> this[int s] => _internal[s] == null
             ? new List<(int, int)>()
             : _internal[s].Select(kvp => (kvp.Key, kvp.Value)).ToList();
 
         /// <summary>
-        /// Verifica se existe o evento 'e' no estado 's'
+        /// Checks whether event 'e' exists in state 's'
         /// </summary>
         public bool HasEvent(int s, int e)
         {
-            // se _events[s] ainda não foi criado, não tem evento
+            // If _events[s] has not been created yet, there is no event
             if (_events[s] == null) return false;
             return _events[s][e];
         }
 
         /// <summary>
-        /// Adiciona múltiplos pares (evento, destino) para o estado 'origin'
+        /// Adds multiple (event, destination) pairs to state 'origin'
         /// </summary>
         public void Add(int origin, (int, int)[] values)
         {
@@ -76,7 +76,7 @@ namespace UltraDES
                 }
                 else
                 {
-                    // se já existe, checa determinismo
+                    // If it already exists, checks determinism
                     if (_internal[origin][evt] != dest)
                         throw new Exception("Automaton is not deterministic.");
                 }
@@ -84,7 +84,7 @@ namespace UltraDES
         }
 
         /// <summary>
-        /// Adiciona um par (evento, destino) ao estado 'origin'
+        /// Adds an (event, destination) pair to state 'origin'
         /// </summary>
         public void Add(int origin, int e, int dest)
         {
@@ -101,14 +101,14 @@ namespace UltraDES
             }
             else
             {
-                // se já existe, checa determinismo
+                // If it already exists, checks determinism
                 if (_internal[origin][e] != dest)
                     throw new Exception("Automaton is not deterministic.");
             }
         }
 
         /// <summary>
-        /// Remove o evento 'e' do estado 'origin'
+        /// Removes event 'e' from state 'origin'
         /// </summary>
         public void Remove(int origin, int e)
         {
@@ -117,7 +117,7 @@ namespace UltraDES
         }
 
         /// <summary>
-        /// Clona a matriz de adjacência
+        /// Clones the adjacency matrix
         /// </summary>
         public IAdjacencyMatrixImplementation Clone()
         {
@@ -126,14 +126,14 @@ namespace UltraDES
             {
                 if (_internal[s] != null)
                 {
-                    // clona a SortedList
+                    // Clones the SortedList
                     clone._internal[s] = new SortedList<int, int>();
                     foreach (var kv in _internal[s])
                     {
                         clone._internal[s].Add(kv.Key, kv.Value);
                     }
                 }
-                // clona o array de bool
+                // Clones the bool array
                 if (_events[s] != null)
                 {
                     clone._events[s] = new bool[EventsNum];
@@ -144,7 +144,7 @@ namespace UltraDES
         }
 
         /// <summary>
-        /// Solicita às coleções internas que liberem memória extra
+        /// Requests that the internal collections release extra memory
         /// </summary>
         public void TrimExcess()
         {

--- a/UltraDES/Data Structures/AdjacencyMatrixBoolArray.cs
+++ b/UltraDES/Data Structures/AdjacencyMatrixBoolArray.cs
@@ -40,9 +40,11 @@ namespace UltraDES
             => HasEvent(s, e) ? _internal[s][e] : -1;
 
         /// <summary>
-        /// Indexador [s]: retorna a SortedList<evento, destino> para o estado 's' (criando se for null)
+        /// Indexador [s]: retorna as transições do estado ou uma lista vazia quando não houver nenhuma.
         /// </summary>
-        public List<(int, int)> this[int s] => _internal[s].Select(kvp => (kvp.Key, kvp.Value)).ToList();
+        public List<(int, int)> this[int s] => _internal[s] == null
+            ? new List<(int, int)>()
+            : _internal[s].Select(kvp => (kvp.Key, kvp.Value)).ToList();
 
         /// <summary>
         /// Verifica se existe o evento 'e' no estado 's'

--- a/UltraDES/Data Structures/AdjacencyMatrixUIntImpl.cs
+++ b/UltraDES/Data Structures/AdjacencyMatrixUIntImpl.cs
@@ -35,8 +35,10 @@ internal sealed class AdjacencyMatrixUIntImpl : IAdjacencyMatrixImplementation
     // Indexador [s,e]: retorna destino ou -1 se não existe
     public int this[int s, int e] => HasEvent(s, e) ? _internal[s][e] : -1;
 
-    // Indexador [s]: retorna SortedList, cria se null
-    public List<(int, int)> this[int s] => _internal[s].Select(kvp => (kvp.Key, kvp.Value)).ToList();
+    // Indexador [s]: retorna as transições do estado ou uma lista vazia.
+    public List<(int, int)> this[int s] => _internal[s] == null
+        ? new List<(int, int)>()
+        : _internal[s].Select(kvp => (kvp.Key, kvp.Value)).ToList();
 
     public bool HasEvent(int s, int e)
     {

--- a/UltraDES/Data Structures/AdjacencyMatrixUIntImpl.cs
+++ b/UltraDES/Data Structures/AdjacencyMatrixUIntImpl.cs
@@ -8,7 +8,7 @@ namespace UltraDES;
 internal sealed class AdjacencyMatrixUIntImpl : IAdjacencyMatrixImplementation
 {
     private readonly SortedList<int, int>[] _internal;
-    private readonly uint[] _eventMask; // 1 bit por evento, total 32 bits
+    private readonly uint[] _eventMask; // 1 bit per event, 32 bits in total
 
     public int Length => _internal.Length;
     public int EventsNum { get; }
@@ -16,7 +16,7 @@ internal sealed class AdjacencyMatrixUIntImpl : IAdjacencyMatrixImplementation
     public AdjacencyMatrixUIntImpl(int states, int eventsNum, bool preAllocate = false)
     {
         if (eventsNum > 32)
-            throw new ArgumentException("AdjacencyMatrixUIntImpl suporta no máximo 32 eventos.", nameof(eventsNum));
+            throw new ArgumentException("AdjacencyMatrixUIntImpl supports at most 32 events.", nameof(eventsNum));
 
         EventsNum = eventsNum;
         _internal = new SortedList<int, int>[states];
@@ -32,10 +32,10 @@ internal sealed class AdjacencyMatrixUIntImpl : IAdjacencyMatrixImplementation
         }
     }
 
-    // Indexador [s,e]: retorna destino ou -1 se não existe
+    // Indexer [s,e]: returns the destination or -1 if it does not exist
     public int this[int s, int e] => HasEvent(s, e) ? _internal[s][e] : -1;
 
-    // Indexador [s]: retorna as transições do estado ou uma lista vazia.
+    // Indexer [s]: returns the state transitions or an empty list.
     public List<(int, int)> this[int s] => _internal[s] == null
         ? new List<(int, int)>()
         : _internal[s].Select(kvp => (kvp.Key, kvp.Value)).ToList();

--- a/UltraDES/Data Structures/AdjacencyMatrixUShortImpl.cs
+++ b/UltraDES/Data Structures/AdjacencyMatrixUShortImpl.cs
@@ -8,7 +8,7 @@ namespace UltraDES;
 internal sealed class AdjacencyMatrixUShortImpl : IAdjacencyMatrixImplementation
 {
     private readonly SortedList<int, int>[] _internal;
-    private readonly ushort[] _eventMask; // 1 bit por evento, total 16 bits
+    private readonly ushort[] _eventMask; // 1 bit per event, 16 bits in total
 
     public int Length => _internal.Length;
     public int EventsNum { get; }
@@ -16,7 +16,7 @@ internal sealed class AdjacencyMatrixUShortImpl : IAdjacencyMatrixImplementation
     public AdjacencyMatrixUShortImpl(int states, int eventsNum, bool preAllocate = false)
     {
         if (eventsNum > 16)
-            throw new ArgumentException("AdjacencyMatrixUShortImpl suporta no máximo 16 eventos.", nameof(eventsNum));
+            throw new ArgumentException("AdjacencyMatrixUShortImpl supports at most 16 events.", nameof(eventsNum));
 
         EventsNum = eventsNum;
         _internal = new SortedList<int, int>[states];
@@ -30,13 +30,13 @@ internal sealed class AdjacencyMatrixUShortImpl : IAdjacencyMatrixImplementation
         }
     }
 
-    // Indexador [s,e]: retorna destino ou -1 se não existe
+    // Indexer [s,e]: returns the destination or -1 if it does not exist
     public int this[int s, int e]
     {
         get => HasEvent(s, e) ? _internal[s][e] : -1;
     }
 
-    // Indexador [s]: retorna as transições do estado ou uma lista vazia.
+    // Indexer [s]: returns the state transitions or an empty list.
     public List<(int, int)> this[int s]
     {
         get => _internal[s] == null

--- a/UltraDES/Data Structures/AdjacencyMatrixUShortImpl.cs
+++ b/UltraDES/Data Structures/AdjacencyMatrixUShortImpl.cs
@@ -36,10 +36,12 @@ internal sealed class AdjacencyMatrixUShortImpl : IAdjacencyMatrixImplementation
         get => HasEvent(s, e) ? _internal[s][e] : -1;
     }
 
-    // Indexador [s]: retorna SortedList, cria se null
+    // Indexador [s]: retorna as transições do estado ou uma lista vazia.
     public List<(int, int)> this[int s]
     {
-        get => _internal[s].Select(kvp => (kvp.Key, kvp.Value)).ToList();
+        get => _internal[s] == null
+            ? new List<(int, int)>()
+            : _internal[s].Select(kvp => (kvp.Key, kvp.Value)).ToList();
     }
 
     public bool HasEvent(int s, int e)

--- a/UltraDES/UltraDES.csproj
+++ b/UltraDES/UltraDES.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>12.0</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.2.5.1</Version>
+    <Version>2.2.5.2</Version>
     <Authors>Developers of LACSED</Authors>
     <Company>LACSED | UFMG</Company>
     <Description>UltraDES is a library for modeling, analysis and control of Discrete Event Systems.</Description>
@@ -15,8 +15,8 @@
     <NeutralLanguage>en</NeutralLanguage>
     <PackageReleaseNotes>- Implementation of algorithms for diagnosticability and opacity of discrete event systems</PackageReleaseNotes>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <AssemblyVersion>2.2.5.1</AssemblyVersion>
-    <FileVersion>2.2.5.1</FileVersion>
+    <AssemblyVersion>2.2.5.2</AssemblyVersion>
+    <FileVersion>2.2.5.2</FileVersion>
     <RepositoryUrl>https://github.com/lacsed/UltraDES</RepositoryUrl>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -42,5 +42,5 @@
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
### Motivation
- A composição de autômatos falhava com `ArgumentNullException` quando uma linha esparsa da matriz de adjacência não estava alocada (estados sem transições) e o indexador aplicava LINQ sobre `null` em vez de retornar uma coleção vazia.

### Description
- Ajustado o indexador que retorna transições para que devolva uma lista vazia quando a linha interna não estiver alocada, evitando chamadas a LINQ sobre `null` nas implementações `BitArray`, `BitMask`, `BoolArray`, `UInt` e `UShort`.
- Documentada a semântica do indexador em `AdjacencyMatrix` para explicitar que `this[int s]` retorna uma lista vazia quando não houver transições.
- A mudança aplica o comportamento de forma consistente a todas as implementações da matriz de adjacência para evitar regressões dependendo da implementação escolhida.

### Testing
- Executado um teste de regressão com `dotnet run --project /tmp/ultrades-regression/regression.csproj` que compõe dois autômatos e verificou as implementações `USHORT`, `UINT`, `BITMASK`, `BITARRAY` e `BOOLARRAY`, e todos passaram.
- Executado `dotnet restore UltraDES.sln && dotnet build UltraDES.sln --no-restore` e a solução foi compilada com sucesso (apenas avisos preexistentes foram emitidos).
- Executado `git diff --check` para validação de alterações de estilo/whitespace e não foram encontrados problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71ee37f930832caf690efe546c7f2b)