### PR TITLE
Add comprehensive wiki documentation and examples for UltraDES

### DIFF
--- a/wiki/Automata-modeling.md
+++ b/wiki/Automata-modeling.md
@@ -1,0 +1,66 @@
+# Automata modeling
+
+## States
+
+```csharp
+var q0 = new State("q0", Marking.Unmarked);
+var q1 = new State("q1", Marking.Marked);
+```
+
+`Marking.Marked` identifies an accepting/marked state; `Marking.Unmarked` identifies a nonmarked state. `AbstractState` is the common base type. `CompoundState` represents a state assembled from component states during operations such as composition.
+
+The main DFA state properties are:
+
+- `InitialState`: returns the starting state;
+- `States`: enumerates every state in the automaton;
+- `MarkedStates`: enumerates only marked states;
+- `Size`: returns the number of states.
+
+## Events
+
+```csharp
+var start = new Event("start", Controllability.Controllable);
+var failure = new Event("failure", Controllability.Uncontrollable);
+```
+
+A controllable event may be disabled by a supervisor. An uncontrollable event models an occurrence the supervisor cannot prevent. `Events` returns the DFA alphabet, while `UncontrollableEvents` filters that alphabet by controllability. `Epsilon` and `Empty` are special language symbols used by regular-expression operations.
+
+## Transitions and deterministic automata
+
+```csharp
+var transitions = new[]
+{
+    new Transition(q0, start, q1),
+    new Transition(q1, failure, q0)
+};
+var g = new DeterministicFiniteAutomaton(transitions, q0, "G");
+```
+
+A `Transition` exposes `Origin`, `Trigger`, and `Destination`. A DFA can have at most one destination for a given state/event pair.
+
+## Querying a transition
+
+```csharp
+var result = g.TransitionFunction(q0, start);
+if (result is Some<AbstractState> destination)
+    Console.WriteLine(destination.Value);
+```
+
+`TransitionFunction` checks whether an event is defined at a state. It returns `Some<AbstractState>` with the destination when found, or `None<AbstractState>` when no transition exists.
+
+## Nondeterministic automata
+
+`NondeterministicFiniteAutomaton` exposes `Transitions`, `InitialState`, `States`, `MarkedStates`, and `Events`. Unlike a DFA, it may represent alternative destinations for the same state/event pair. In UltraDES it is especially useful as the result of observer-property searches.
+
+## Copying and simplifying names
+
+```csharp
+var copy = g.Clone();
+var simplified = g.SimplifyStatesName(out var stateMap);
+```
+
+- `Clone()` copies the DFA;
+- `Clone(capacity)` copies it while reserving internal capacity;
+- `SimplifyStatesName()` replaces compound/long state names with simpler names;
+- `SimplifyStatesName(out map)` also returns the old-to-new state mapping;
+- `simplifyName(newName, simplifyStatesName)` is a legacy naming helper that can rename the automaton and simplify state labels.

--- a/wiki/Automata-operations.md
+++ b/wiki/Automata-operations.md
@@ -1,0 +1,61 @@
+# Automata operations
+
+Assume `g1` and `g2` are previously constructed DFAs.
+
+## State-space transformations
+
+```csharp
+var accessible = g1.AccessiblePart;
+var coaccessible = g1.CoaccessiblePart;
+var trim = g1.Trim;
+var minimal = g1.Minimal;
+var prefixClosed = g1.PrefixClosure;
+```
+
+| Member | What it computes or checks |
+|---|---|
+| `AccessiblePart` | Removes states that cannot be reached from the initial state |
+| `CoaccessiblePart` | Keeps states from which a marked state can be reached |
+| `Trim` | Keeps states that are both accessible and coaccessible |
+| `Minimal` | Merges equivalent states while preserving the accepted language |
+| `PrefixClosure` | Produces the prefix-closed behavior by marking reachable behavior appropriately |
+
+## Parallel composition
+
+```csharp
+var system = g1.ParallelCompositionWith(g2);
+var all = DeterministicFiniteAutomaton.ParallelComposition(new[] { g1, g2 });
+```
+
+Parallel composition synchronizes shared events. A private event changes only the component that contains it. The optional `removeNoAccessibleStates` argument controls whether inaccessible composed states are discarded.
+
+## Product
+
+```csharp
+var product = g1.ProductWith(g2);
+var allProducts = DeterministicFiniteAutomaton.Product(new[] { g1, g2 });
+```
+
+`Product`/`ProductWith` construct a synchronized product used by language checks and related algorithms. Unlike parallel composition, product behavior is restricted by the participating alphabets; use parallel composition to model components with private events.
+
+## Projection and inverse projection
+
+```csharp
+var observed = g1.Projection(unobservableEvent);
+var extended = observed.InverseProjection(g1.Events);
+```
+
+`Projection` hides the supplied events from the observed language. `InverseProjection` extends a model to a larger alphabet, allowing events absent from the original alphabet without changing its projected behavior.
+
+## Structural comparison and language conversion
+
+```csharp
+bool sameShape = DeterministicFiniteAutomaton.Isomorphism(g1, g2);
+var expression = g1.ToRegularExpression;
+```
+
+`Isomorphism` verifies whether two automata have the same transition structure up to state renaming. `ToRegularExpression` converts the DFA language into a regular-expression representation. Minimizing both DFAs before an isomorphism check is a practical way to compare deterministic language representations when the expected assumptions hold.
+
+## Complexity note
+
+Composition and product may approach the Cartesian product of component state spaces. Apply `Trim` or `Minimal` first when that preserves the intended analysis, and consider disk storage for large models.

--- a/wiki/Graph-algorithms.md
+++ b/wiki/Graph-algorithms.md
@@ -1,0 +1,42 @@
+# Graph algorithms
+
+`UltraDES.Graph` provides extension methods for graphs represented as tuple sequences. This makes it possible to analyze automata and Petri-net results without creating another graph type.
+
+## Unlabeled graphs
+
+```csharp
+var edges = new[]
+{
+    (o: "A", d: "B"),
+    (o: "B", d: "C"),
+    (o: "C", d: "A")
+};
+
+var visited = edges.BreadthFirstSearch("A");
+var reversed = edges.ReverseEdges();
+var between = edges.VerticesBetween("A", "C");
+var components = edges.StronglyConnectedComponents((x, y) => x == y);
+```
+
+- `BreadthFirstSearch` enumerates vertices reachable from a starting vertex in breadth-first order;
+- `ReverseEdges` swaps every edge origin and destination;
+- `VerticesBetween` finds vertices reachable from the first endpoint that can also reach the second;
+- `StronglyConnectedComponents` groups vertices that can mutually reach each other.
+
+Overloads accepting `Func<T,T,bool>` allow domain-specific vertex equality.
+
+## Labeled graphs and Graphviz
+
+```csharp
+var labeled = new[]
+{
+    (o: "A", l: "start", d: "B"),
+    (o: "B", l: "finish", d: "C")
+};
+
+var simple = labeled.ToUnlabeledEdges();
+string dot = labeled.ToDotCode();
+labeled.ShowGraph("Flow");
+```
+
+`ToUnlabeledEdges` discards edge labels. `ToDotCode` produces a Graphviz document. `ShowGraph` passes that document to the configured viewer; on a headless environment, save the DOT string instead.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,25 @@
+# UltraDES Wiki
+
+**UltraDES** is a .NET library for modeling, analysis, and supervisory control of Discrete Event Systems (DES). This wiki groups the public features by task and illustrates them with small C# examples.
+
+## Suggested reading order
+
+1. [Installation and first steps](Installation-and-first-steps.md)
+2. [Automata modeling](Automata-modeling.md)
+3. [Automata operations](Automata-operations.md)
+4. [Supervisory control](Supervisory-control.md)
+5. [Input, output, and visualization](Input-output-and-visualization.md)
+6. [Regular expressions](Regular-expressions.md)
+7. [Observer, diagnosability, and opacity](Observer-diagnosability-and-opacity.md)
+8. [Petri nets](Petri-nets.md)
+9. [Graph algorithms](Graph-algorithms.md)
+
+## Conventions used in this wiki
+
+- `DFA` is an alias for `DeterministicFiniteAutomaton`.
+- A marked state normally represents successful task completion or an accepted word.
+- An uncontrollable event cannot be disabled by a supervisor.
+- `AccessiblePart`, `Trim`, and `Minimal` are computed properties, so they are used without parentheses.
+- Operations normally return a new automaton. Keep the original reference if the unmodified model is still needed.
+
+> `KleeneClosure` is present in the DFA API but currently throws `NotImplementedException`. To express closure at the language level, use `ToRegularExpression` followed by `RegularExpression.Kleene`.

--- a/wiki/Input-output-and-visualization.md
+++ b/wiki/Input-output-and-visualization.md
@@ -1,0 +1,55 @@
+# Input, output, and visualization
+
+## Supported formats
+
+| Format | Read | Write | Purpose |
+|---|---|---|---|
+| ADS | `FromAdsFile`, `FromAdsString` | `ToAdsFile` | Import/export ADS automata |
+| FSM | `FromFsmFile`, `FromFsmString` | `ToFsmFile`, `ToFsm` | Exchange textual finite-state machines |
+| WMod | `FromWmodFile`, `FromWmodString` | `ToWmodFile`, `ToWmodString` | Exchange plants and specifications with Supremica-style modules |
+| XML | `FromXMLFile`, `FromXMLString`, `DeserializeAutomaton` | `ToXMLFile`, `ToXML`, `SerializeAutomaton` | Persist one automaton in XML |
+| JSON | `FromJsonFile`, `FromJsonString` | `ToJsonFile`, `ToJsonString` | Persist a collection of automata |
+| FM | — | `ToFmFile` | Export the FM representation (`ToFM` is a legacy alias) |
+
+## Reading and writing models
+
+```csharp
+using DFA = UltraDES.DeterministicFiniteAutomaton;
+
+DFA.FromWmodFile("model.wmod", out var plants, out var specs);
+var supervisor = DFA.MonolithicSupervisor(plants, specs);
+supervisor.ToFsmFile("supervisor.fsm");
+```
+
+WMod readers separate plant and specification automata. The `From...File` methods read a path, whereas `From...String` methods parse document content.
+
+```csharp
+DFA.ToJsonFile("models.json", plants.Concat(specs));
+var models = DFA.FromJsonFile("models.json");
+
+string xml = supervisor.ToXML;
+var restored = DFA.FromXMLString(xml);
+```
+
+JSON methods support multiple automata. XML members are convenient for a single DFA; `SerializeAutomaton` and `DeserializeAutomaton` are file-based alternatives.
+
+## DOT and figures
+
+```csharp
+string dot = supervisor.ToDotCode;
+supervisor.ShowAutomaton("Supervisor");
+supervisor.drawSVGFigure("supervisor.svg", openAfterFinish: false);
+supervisor.drawLatexFigure("supervisor.tex", openAfterFinish: false);
+```
+
+`ToDotCode` returns a Graphviz description. `ShowAutomaton` opens the available viewer. The figure methods render SVG or LaTeX output; set `openAfterFinish` to `false` on CI servers or other headless environments.
+
+## Highlighting states, events, and transitions
+
+```csharp
+var states = new[] { (supervisor.InitialState, SVGColors.LightBlue) };
+var dot = supervisor.ToFormattedDotCode(states);
+supervisor.ShowFormattedAutomaton(states, name: "Highlighted supervisor");
+```
+
+Formatting overloads accept `(Transition, SVGColors, GraphVizStyle)` to style individual transitions, or `(AbstractEvent, SVGColors)` to style every transition triggered by an event. `SVGColors` supplies named colors and `GraphVizStyle` selects line styles.

--- a/wiki/Installation-and-first-steps.md
+++ b/wiki/Installation-and-first-steps.md
@@ -1,0 +1,62 @@
+# Installation and first steps
+
+## Requirements
+
+- A .NET SDK compatible with `netstandard2.1`;
+- a C# IDE or editor, such as Visual Studio, VS Code, Rider, or LINQPad;
+- either the UltraDES NuGet package or a reference to `UltraDES/UltraDES.csproj`.
+
+Install the package in an existing project:
+
+```bash
+dotnet add package UltraDES
+```
+
+To work from this repository instead:
+
+```bash
+dotnet build UltraDES.sln
+```
+
+## First automaton
+
+```csharp
+using UltraDES;
+
+var idle = new State("Idle", Marking.Marked);
+var active = new State("Active", Marking.Unmarked);
+var start = new Event("start", Controllability.Controllable);
+var stop = new Event("stop", Controllability.Uncontrollable);
+
+var machine = new DeterministicFiniteAutomaton(new[]
+{
+    new Transition(idle, start, active),
+    new Transition(active, stop, idle)
+}, idle, "Machine");
+
+Console.WriteLine($"{machine.Name}: {machine.Size} states");
+```
+
+The constructor receives the transitions, initial state, and model name. The state set and event alphabet are inferred from the transitions. It also accepts transition tuples of the form `(state, event, state)`.
+
+## Repository examples
+
+| Project | Demonstrates |
+|---|---|
+| `DFA Functions and Properties` | DFA properties and transformations |
+| `Supervisor Synthesis` | Monolithic and local modular synthesis |
+| `Reading Files` | WMod model loading |
+| `Algorithms` | Observer-property algorithms |
+| `Opacity and Diagnosability` | Observers, diagnosability, and opacity |
+| `Petri Nets` | Petri-net construction and coverability |
+| `linqpad-samples` | Interactive introductory and control examples |
+
+## Large-model settings
+
+```csharp
+DeterministicFiniteAutomaton.Multicore = true;
+DeterministicFiniteAutomaton.UseDiskStorage = true;
+DeterministicFiniteAutomaton.DiskStorageTempPath = "/tmp/ultrades";
+```
+
+`Multicore` enables internal parallel processing. `UseDiskStorage` moves some adjacency data to disk, reducing memory pressure at the cost of I/O. `DiskStorageTempPath` selects the writable directory used for that storage.

--- a/wiki/Observer-diagnosability-and-opacity.md
+++ b/wiki/Observer-diagnosability-and-opacity.md
@@ -1,0 +1,55 @@
+# Observer, diagnosability, and opacity
+
+## Observer property
+
+```csharp
+AbstractEvent[] relevantEvents = { eventA };
+bool holds = system.ObserverPropertyVerify(relevantEvents, out var verifier);
+var witness = system.ObserverPropertySearch(relevantEvents);
+```
+
+`ObserverPropertyVerify` checks whether projected observations preserve the marked-language information required by the observer property. It returns an auxiliary nondeterministic automaton through `out`; `returnOnDead` can stop the search at the first violation. `ObserverPropertySearch` builds the search automaton used to inspect or witness violations.
+
+The observer module also exposes:
+
+- `TarjanSCC`, which finds strongly connected components in a transition graph;
+- `StronglyConnectedComponentsAutomaton`, which creates an automaton representation related to those components while accounting for nonrelevant events.
+
+## Observer construction and diagnosability
+
+```csharp
+using UltraDES.Diagnosability;
+
+var unobservable = new HashSet<AbstractEvent> { failure };
+var observer = DiagnosticsAlgoritms.CreateObserver(system, unobservable);
+bool diagnosable = DiagnosticsAlgoritms.IsDiagnosable(observer);
+```
+
+`CreateObserver` groups states that cannot be distinguished after hiding the supplied unobservable events. `IsDiagnosable` checks the observer for indefinitely ambiguous normal/faulty behavior. The system must encode normal and post-failure behavior—commonly by composing it with a labeler—so the observer contains the information needed for that check.
+
+## Language-based opacity
+
+```csharp
+using UltraDES.Opacity;
+
+bool opaque = OpacityAlgorithms.LanguageBasedOpacity(
+    secretLanguage, nonSecretLanguage, unobservable);
+```
+
+`LanguageBasedOpacity` projects the secret and nonsecret languages and checks whether an observer can distinguish them.
+
+## State-based opacity notions
+
+UltraDES also provides:
+
+- `InitialStateOpacity`: checks whether an observation can reveal that execution began in a secret state;
+- `InitialFinalStateOpacity`: checks whether an observation can reveal a secret initial/final-state relation;
+- `CurrentStepOpacity`: checks whether the current state can be known to be secret;
+- `KStepsOpacity`: checks whether a state within the last `K` observed steps can be known to have been secret.
+
+```csharp
+bool currentStateOpaque = OpacityAlgorithms.CurrentStepOpacity(
+    system, unobservableEvents, secretStates, out var estimator);
+```
+
+The exact state-set and event-set parameters differ by opacity notion; use the overload appropriate to the installed version. A `true` result means the secret cannot be inferred under that definition and observation model.

--- a/wiki/Petri-nets.md
+++ b/wiki/Petri-nets.md
@@ -1,0 +1,65 @@
+# Petri nets
+
+Petri-net types are in `UltraDES.PetriNets`. Since `UltraDES` also defines a `Transition`, aliases avoid ambiguity.
+
+## Construction
+
+```csharp
+using UltraDES.PetriNets;
+using PNMarking = UltraDES.PetriNets.Marking;
+using PNTransition = UltraDES.PetriNets.Transition;
+
+var free = new Place("free");
+var busy = new Place("busy");
+var enter = new PNTransition("enter");
+var leave = new PNTransition("leave");
+
+var net = new PetriNet(new (Node, Node, uint)[]
+{
+    (free, enter, 1), (enter, busy, 1),
+    (busy, leave, 1), (leave, free, 1)
+}, "Resource");
+
+var m0 = new PNMarking(new[] { (free, 1u), (busy, 0u) });
+```
+
+Each tuple is an `(origin, destination, weight)` arc. Constructors also accept `Arc` objects, unweighted node pairs (weight 1), or separate input/output arc lists.
+
+## Enabling and firing
+
+```csharp
+var enabled = net.EnabledTransitions(m0).ToArray();
+var m1 = net.Fire(m0, enter);
+var final = net.Fire(m0, new[] { enter, leave });
+```
+
+`EnabledTransitions` checks which transitions have enough input tokens. `Fire` consumes tokens from input places and adds tokens to output places, returning a new marking. `Marking.Update` also returns a new marking. A `null` token value represents `ω` in coverability analysis; the marking indexer returns zero for an absent place.
+
+## Structure and analysis
+
+```csharp
+uint weight = net.Weight(free, enter);
+var inputs = net.Inputs(enter);
+var outputs = net.Outputs(enter);
+bool siphon = net.IsSiphon(new[] { free, busy });
+bool trap = net.IsTrap(new[] { free, busy });
+var matrix = net.IncidenceMatrix(out var placeIndex, out var transitionIndex);
+```
+
+- `Weight`, `Input`, and `Output` query arc weights;
+- `Inputs` and `Outputs` enumerate adjacent nodes;
+- `IsSiphon` checks whether every transition adding tokens to the place set also consumes from it;
+- `IsTrap` checks whether every transition consuming from the set also adds to it;
+- `IncidenceMatrix` calculates token change per place/transition and returns index maps;
+- the `+` operator combines two nets.
+
+## State-space analysis and drawing
+
+```csharp
+var coverability = net.CoverabilityGraph(m0);
+var tree = net.ReachabilityTree(m0);
+net.ShowPetriNet("Resource", m0);
+coverability.ShowGraph("Coverability");
+```
+
+`CoverabilityTree` explores firing sequences and introduces `ω` when token growth is unbounded. `CoverabilityGraph` merges equivalent coverability markings. `ReachabilityTree` enumerates reachable markings without the `ω` abstraction and may not terminate for an unbounded net. `ToDotCode` and `ShowPetriNet` export or display the net.

--- a/wiki/Regular-expressions.md
+++ b/wiki/Regular-expressions.md
@@ -1,0 +1,41 @@
+# Regular expressions
+
+UltraDES represents regular languages through the `RegularExpression` hierarchy.
+
+## Expression elements
+
+| Type | Meaning |
+|---|---|
+| `Symbol` | Base class for language symbols; events are symbols |
+| `Concatenation` | Words from the first expression followed by words from the second |
+| `Union` | Words accepted by either expression |
+| `KleeneStar` | Zero or more repetitions of an expression |
+| `Epsilon` | The empty word |
+| `Empty` | The empty language |
+
+## Building and converting expressions
+
+```csharp
+var a = new Event("a", Controllability.Controllable);
+var b = new Event("b", Controllability.Controllable);
+
+RegularExpression choice = new Union(a, b);
+RegularExpression sequence = new Concatenation(a, b);
+RegularExpression repetition = choice.Kleene;
+
+var automaton = repetition.ToDFA;
+var equivalentExpression = automaton.ToRegularExpression;
+```
+
+Events inherit from `Symbol`, so they can be used directly as expressions. `ToDFA` builds a deterministic automaton that accepts the expression language. `ToRegularExpression` computes an expression that denotes a DFA's language.
+
+## Simplification and projection
+
+```csharp
+var simplified = repetition.Simplify;
+var observed = repetition.Projection(new HashSet<AbstractEvent> { b });
+```
+
+`Simplify` repeatedly applies algebraic simplifications without changing the denoted language. `Projection` hides the supplied events at the language level and is used by language-based opacity checks.
+
+> Do not use `DFA.KleeneClosure` in the current implementation: it throws `NotImplementedException`. Convert the DFA to an expression and use `.Kleene` instead.

--- a/wiki/Supervisory-control.md
+++ b/wiki/Supervisory-control.md
@@ -1,0 +1,59 @@
+# Supervisory control
+
+Supervisory-control workflows separate **plants** (physically possible behavior) from **specifications** (allowed behavior).
+
+## Monolithic synthesis
+
+```csharp
+var supervisor = DeterministicFiniteAutomaton.MonolithicSupervisor(
+    new[] { plant1, plant2 },
+    new[] { specification },
+    nonBlocking: true);
+```
+
+`MonolithicSupervisor` composes the input models and calculates a supervisor that respects uncontrollable behavior. With `nonBlocking: true`, it also removes behavior that cannot reach a marked state. `MonolithicSupervisorLegacy(plant, spec)` retains the older single-plant/single-specification algorithm for compatibility.
+
+## Local modular synthesis
+
+```csharp
+var supervisors = DeterministicFiniteAutomaton
+    .LocalModularSupervisor(plants, specifications)
+    .ToArray();
+
+bool conflicting = DeterministicFiniteAutomaton.IsConflicting(supervisors);
+```
+
+`LocalModularSupervisor` builds supervisors from the plants relevant to each specification, which can avoid a single large global state space. `IsConflicting` checks whether nonblocking local supervisors become blocking when used together. Overloads can include conflict-resolution supervisors and algorithm options.
+
+## Controllability and disabled events
+
+```csharp
+bool controllable = supervisor.IsControllable(plants);
+var status = supervisor.Controllability(plants);
+var disabled = supervisor.DisabledEvents(plants);
+var complete = supervisor.ControllabilityAndDisabledEvents(plants);
+```
+
+- `IsControllable` checks whether the candidate supervisor ever tries to prevent plant behavior caused by an uncontrollable event;
+- `Controllability` returns the corresponding controllability classification;
+- `DisabledEvents` maps supervisor states to plant events disabled at those states;
+- `ControllabilityAndDisabledEvents` obtains the classification and map in one operation.
+
+## Reduction and localization
+
+```csharp
+var reduced = DeterministicFiniteAutomaton.ReduceSupervisor(plant, supervisor);
+var localControllers = DeterministicFiniteAutomaton.LocalizeSupervisor(
+    globalPlant, supervisor, agents);
+```
+
+`ReduceSupervisor` merges compatible supervisor states while preserving relevant control decisions. `LocalizeSupervisor` derives one local controller per agent so distributed controllers reproduce the global decisions.
+
+Combined synthesis helpers are also available:
+
+- `MonolithicReducedSupervisor`;
+- `MonolithicLocalizedSupervisor`;
+- `LocalModularReducedSupervisor`;
+- `LocalModularLocalizedSupervisor`.
+
+Their optional `maxIt` argument limits reduction/localization iterations; it does not limit synthesis state-space generation.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,12 @@
+## UltraDES
+
+- [Home](Home.md)
+- [Installation](Installation-and-first-steps.md)
+- [Automata modeling](Automata-modeling.md)
+- [Automata operations](Automata-operations.md)
+- [Supervisory control](Supervisory-control.md)
+- [Input, output, and visualization](Input-output-and-visualization.md)
+- [Regular expressions](Regular-expressions.md)
+- [Observer, diagnosability, and opacity](Observer-diagnosability-and-opacity.md)
+- [Petri nets](Petri-nets.md)
+- [Graph algorithms](Graph-algorithms.md)


### PR DESCRIPTION
### Motivation

- Provide a structured user guide grouping public API features and workflows for `UltraDES` into task-oriented wiki pages. 
- Illustrate common usage with small C# examples to help users get started with modeling, synthesis, analysis, and visualization. 
- Document supported formats, utilities, and known implementation notes (e.g. `KleeneClosure` not implemented).

### Description

- Add a set of new documentation pages under the `wiki/` directory including `Home.md`, `_Sidebar.md`, `Installation-and-first-steps.md`, `Automata-modeling.md`, `Automata-operations.md`, `Supervisory-control.md`, `Input-output-and-visualization.md`, `Regular-expressions.md`, `Observer-diagnosability-and-opacity.md`, `Petri-nets.md`, and `Graph-algorithms.md` describing library functionality and examples. 
- Provide concise API usage examples for core types and members such as `DeterministicFiniteAutomaton`, `Transition`, `State`, `Event`, `AccessiblePart`, `Trim`, `Minimal`, `ParallelCompositionWith`, and `MonolithicSupervisor`. 
- Document I/O and visualization features including format readers/writers like `FromWmodFile`, `FromJsonFile`, `ToFsmFile`, `ToDotCode`, `ShowAutomaton`, and figure exports like `drawSVGFigure`. 
- Explain higher-level algorithms and analyses including observers, diagnosability, opacity, Petri-net operations (`CoverabilityGraph`, `ReachabilityTree`), and graph helpers such as `BreadthFirstSearch` and `StronglyConnectedComponents`.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dc4fe2338832c8a4c0f9e1a88bdab)