### PR TITLE
🧹 [Code Health] Remove unprofessional development note comment

### DIFF
--- a/UltraDES/Drawing/Drawing.cs
+++ b/UltraDES/Drawing/Drawing.cs
@@ -216,8 +216,6 @@ namespace UltraDES
         /// <returns>Dictionary&lt;System.String, DrawingState&gt;.</returns>
         private static Dictionary<string, DrawingState> prepare(DeterministicFiniteAutomaton G)
         {
-            //CRIANDO MÉTODO QUE SERA UTILIZADO PARA O DESENVOLVIMENTO DA BIBLIOTECA
-
             var drawingStatesList = new Dictionary<string, DrawingState>();           // lista de estados com cordenadas
 
             //Cria uma lista de estados com parametros de posição para serem desenhados


### PR DESCRIPTION
🎯 **What:** Removed an unprofessional development note comment in Portuguese (`//CRIANDO MÉTODO QUE SERA UTILIZADO PARA O DESENVOLVIMENTO DA BIBLIOTECA`) from the `prepare` method in `UltraDES/Drawing/Drawing.cs`.
💡 **Why:** This improves the professional tone and readability of the code by removing an outdated development artifact that provides no value to current maintainers or users.
✅ **Verification:** Rebuilt the solution using `dotnet build UltraDES.sln` to confirm no syntax errors were introduced and that the compilation succeeds.
✨ **Result:** The codebase is slightly cleaner and maintains a more professional appearance without any change in runtime behavior.

---
*PR created automatically by Jules for task [10924705797338430363](https://jules.google.com/task/10924705797338430363) started by @lucasvra*